### PR TITLE
Fix database install details for .env file

### DIFF
--- a/install/installing-on-linux.md
+++ b/install/installing-on-linux.md
@@ -69,10 +69,10 @@ Now create a `.env` config file in the base of repository. Make sure that the da
 
 ```
 DB_HOST=localhost
-DB_NAME=username
-DB_PASS=password
+DB_NAME=ushahidi
 DB_TYPE=MySQLi
-DB_USER=ushahidi
+DB_USER=username
+DB_PASS=password
 ```
 
 ### Set up URL rewrites


### PR DESCRIPTION
I think 'ushahidi' and 'username' were reversed. Also putting username and
password next to eachother makes more sense
